### PR TITLE
Enumerated CORS headers instead of wildcards

### DIFF
--- a/jsonHttpHandler/cors.go
+++ b/jsonHttpHandler/cors.go
@@ -16,8 +16,8 @@ const (
 	VaryHeader                = "Vary"
 
 	Any                            = "*"
-	AllowedMethods                 = Any
-	AllowedHeaders                 = Any
+	AllowedMethods                 = "GET,HEAD,POST,PATCH,PUT,DELETE"
+	AllowedHeaders                 = "Content-Type,Authorization"
 	AccessControlMaxAgeHeaderValue = "86400"
 	VaryHeaderValue                = "Origin"
 )


### PR DESCRIPTION
This is because of firefox: 

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers#Compatibility_notes

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods#Compatibility_notes